### PR TITLE
Add Grafana

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -9,7 +9,7 @@ appVersion: 0.1.0-alpha.1
 
 dependencies:
   - name: timescaledb-single
-    condition: timescale-single.enabled
+    condition: timescaledb-single.enabled
     version: 0.5.5
     repository: https://charts.timescale.com
   - name: timescale-prometheus
@@ -19,4 +19,8 @@ dependencies:
   - name: prometheus
     condition: prometheus.enabled
     version: 11.0.4
+    repository: https://kubernetes-charts.storage.googleapis.com
+  - name: grafana
+    condition: grafana.enabled
+    version: 5.0.11
     repository: https://kubernetes-charts.storage.googleapis.com

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -173,3 +173,26 @@ Get the PushGateway URL by running these commands in the same shell:
 
 For more information on running Prometheus, visit: https://prometheus.io/
 {{- end }}
+
+{{ if .Values.grafana.enabled }}
+##################################################################################
+############################## Notes about Prometheus ############################
+##################################################################################
+{{- $grafanaEnv := (set (set (deepCopy .) "Values" (index .Values "grafana")) "Chart" (dict "Name" "grafana"))  }}
+1. Get your '{{ .Values.grafana.adminUser }}' user password by running:
+
+   kubectl get secret --namespace {{ template "grafana.namespace" $grafanaEnv }} {{ template "grafana.fullname" $grafanaEnv }} -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+
+2. The Grafana server can be accessed via port {{ .Values.grafana.service.port }} on the following DNS name from within your cluster:
+
+   {{ template "grafana.fullname" $grafanaEnv }}.{{ template "grafana.namespace" $grafanaEnv }}.svc.cluster.local
+
+{{- if not .Values.grafana.persistence.enabled }}
+
+#################################################################################
+######   WARNING: Persistence is disabled!!! You will lose your data when   #####
+######            the Grafana pod is terminated.                            #####
+#################################################################################
+{{- end }}
+{{- end -}}
+

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -176,7 +176,7 @@ For more information on running Prometheus, visit: https://prometheus.io/
 
 {{ if .Values.grafana.enabled }}
 ##################################################################################
-############################## Notes about Prometheus ############################
+############################## Notes about Grafana ############################
 ##################################################################################
 {{- $grafanaEnv := (set (set (deepCopy .) "Values" (index .Values "grafana")) "Chart" (dict "Name" "grafana"))  }}
 1. Get your '{{ .Values.grafana.adminUser }}' user password by running:
@@ -195,4 +195,3 @@ For more information on running Prometheus, visit: https://prometheus.io/
 #################################################################################
 {{- end }}
 {{- end -}}
-

--- a/chart/templates/configmap-prometheus.yaml
+++ b/chart/templates/configmap-prometheus.yaml
@@ -20,7 +20,7 @@ data:
 {{- $shouldHaveRemoteWriteKey := or $remoteWrite $tsPromValues.enabled -}}
 {{- $dummyChart := dict "Name" "timescale-prometheus" -}}
 {{- $tsPromContext := dict "Release" $root.Release "Chart" $dummyChart "Values" $tsPromValues -}}
-{{- $tsPromUrl := printf "http://%s.%s:%s" (include "timescale-observability.fullname" $tsPromContext) "default.svc.cluster.local" $tsPromValues.service.port -}}
+{{- $tsPromUrl := printf "http://%s.%s.svc.cluster.local:%.0f" (include "timescale-observability.fullname" $tsPromContext) $root.Release.Namespace $tsPromValues.service.port -}}
 {{- if $shouldHaveRemoteWriteKey }}
     remote_write:
 {{- if $tsPromValues.enabled -}}

--- a/chart/templates/secret-grafana-datasources.yaml
+++ b/chart/templates/secret-grafana-datasources.yaml
@@ -1,0 +1,33 @@
+{{ if .Values.prometheus.server.enabled -}}
+{{ if .Values.grafana.enabled -}}
+{{- $promEnv := (set (set (deepCopy .) "Values" .Values.prometheus) "Chart" (dict "Name" "prometheus")) -}}
+{{- $serverName := (include "prometheus.server.fullname" $promEnv) -}}
+{{- $serverUrl := printf "http://%s.%s.svc.cluster.local:%.0f" $serverName .Release.Namespace .Values.prometheus.server.service.servicePort -}}
+apiVersion: v1
+kind: Secret
+metadata: 
+  name: {{ .Release.Name }}-grafana-datasources
+  labels:
+    grafana_datasource: "1"
+    app: {{ template "timescale-observability.fullname" . }}
+    chart: {{ template "timescale-observability.chart" . }}
+    release: {{ .Release.Name }}
+type: Opaque
+stringData: 
+  datasource.yaml: |-
+    # config file version
+    apiVersion: 1
+    
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: {{ $serverUrl }}
+        isDefault: true
+        editable: true
+        access: proxy
+{{- else -}}
+# A prometheus data source for grafana is created only if grafana is enabled
+{{- end -}}
+{{- else -}}
+# A prometheus data source for grafana is created only if the prometheus server is enabled
+{{- end -}}

--- a/chart/templates/secret-grafana-datasources.yaml
+++ b/chart/templates/secret-grafana-datasources.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.prometheus.server.enabled -}}
+{{- $promEnabled := .Values.prometheus.server.enabled -}}
+{{- $tsEnabled := index .Values "timescaledb-single" "enabled" -}}
+{{- $anyDataSources := or $tsEnabled $promEnabled -}}
+{{ if $anyDataSources -}}
 {{ if .Values.grafana.enabled -}}
-{{- $promEnv := (set (set (deepCopy .) "Values" .Values.prometheus) "Chart" (dict "Name" "prometheus")) -}}
-{{- $serverName := (include "prometheus.server.fullname" $promEnv) -}}
-{{- $serverUrl := printf "http://%s.%s.svc.cluster.local:%.0f" $serverName .Release.Namespace .Values.prometheus.server.service.servicePort -}}
 apiVersion: v1
 kind: Secret
 metadata: 
@@ -19,15 +19,35 @@ stringData:
     apiVersion: 1
     
     datasources:
+{{- if $promEnabled -}}
+{{- $promEnv := (set (set (deepCopy .) "Values" .Values.prometheus) "Chart" (dict "Name" "prometheus")) -}}
+{{- $promServerName := (include "prometheus.server.fullname" $promEnv) -}}
+{{- $promServerUrl := printf "http://%s.%s.svc.cluster.local:%.0f" $promServerName .Release.Namespace .Values.prometheus.server.service.servicePort }}
       - name: Prometheus
         type: prometheus
-        url: {{ $serverUrl }}
+        url: {{ $promServerUrl }}
         isDefault: true
         editable: true
         access: proxy
-{{- else -}}
-# A prometheus data source for grafana is created only if grafana is enabled
 {{- end -}}
-{{- else -}}
-# A prometheus data source for grafana is created only if the prometheus server is enabled
+{{- if $tsEnabled -}}
+{{- $isDefault := not $promEnabled -}}
+{{- $tsEnv := (set (set (deepCopy .) "Values" (index .Values "timescaledb-single")) "Chart" (dict "Name" "timescaledb")) -}}
+{{- $tsHost := printf "%s.%s.svc.cluster.local" (include "clusterName" $tsEnv ) .Release.Namespace }}
+      - name: TimescaleDB
+        url: {{ $tsHost }}
+        type: postgres
+        isDefault: {{ $isDefault }}
+        access: proxy
+        user: postgres
+        database: postgres
+        editable: true
+        secureJsonData:
+          password: {{ index .Values "timescaledb-single" "credentials" "postgres" }}
+        jsonData:
+          sslmode: require
+          postgresVersion: 1000
+          timescaledb: true
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -41,9 +41,6 @@ timescale-prometheus:
   
   # configuration options for the service exposed by timescale-prometheus
   service:
-    # port must be passed as string because the prometheus-config-map 
-    # created in this chart can properly set the url for the remote_write endpoint
-    port: "9201"
     # we disable the load balancer by default, only a ClusterIP service
     # will get created
     loadBalancer:
@@ -78,3 +75,12 @@ prometheus:
     # a remote endpoint for read/write (if enabled)
     configMapOverrideName: "prometheus-config"
     
+# Values for configuring the deployment of Grafana
+# The stable/grafana chart is used and the guide for it
+# can be found at:
+#   https://hub.helm.sh/charts/stable/grafana
+grafana:
+  enabled: true
+  sidecar:
+    datasources:
+      enabled: true


### PR DESCRIPTION
The stable/grafana subchart is added as a dependency
to be deployed. If the Prometheus server or TimescaleDB are
enabled they will be added as a provisioned data sources.