### PR TITLE
Add job to update PG searchpath if grafana enabled

### DIFF
--- a/chart/templates/job-grafana-ts-searchpath.yaml
+++ b/chart/templates/job-grafana-ts-searchpath.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.grafana.enabled -}}
+{{- $ds := .Values.grafana.sidecar.datasources -}}
+{{- if $ds.enabled -}}
+{{- if $ds.timescaledb.alterSearchPath -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "timescale-observability.fullname" . }}-search-path
+  labels:
+    app: {{ template "timescale-observability.fullname" . }}
+    chart: {{ template "timescale-observability.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}-search-path
+          image: postgres:12-alpine
+          env:
+            - name: PGPORT
+              value: "5432"
+            - name: PGUSER
+              value: {{ $ds.timescaledb.user }}
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl $ds.timescaledb.passwordSecretTemplate . }}
+                  key: {{ $ds.timescaledb.user }}
+            - name: PGHOST
+              value: {{ tpl $ds.timescaledb.urlTemplate . }}
+          command: ['psql', '-c', {{ printf "ALTER ROLE %s SET search_path = prom,_prom_catalog,public;" $ds.timescaledb.user | quote }}]
+      restartPolicy: OnFailure
+      initContainers:
+        - name: init-db
+          image: busybox:1.28
+          env:
+            - name: PGHOST
+              value: {{ tpl $ds.timescaledb.urlTemplate . }}
+          command: ['sh', '-c', "until nslookup ${PGHOST}; do echo waiting for ${PGHOST}; sleep 2; done"]
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/secret-grafana-datasources.yaml
+++ b/chart/templates/secret-grafana-datasources.yaml
@@ -1,9 +1,10 @@
-{{- $promEnabled := .Values.prometheus.server.enabled -}}
-{{- $tsEnabled := index .Values "timescaledb-single" "enabled" -}}
-{{- $anyDataSources := or $tsEnabled $promEnabled -}}
-{{ if $anyDataSources -}}
 {{ if .Values.grafana.enabled -}}
-{{ if .Values.grafana.sidecar.datasources.enabled }}
+{{- $ds := .Values.grafana.sidecar.datasources -}}
+{{ if $ds.enabled }}
+{{- $tsEnabled := $ds.timescaledb.enabled -}}
+{{- $promEnabled := $ds.prometheus.enabled -}}
+{{- $anyDataSources := and $tsEnabled $promEnabled -}}
+{{ if $anyDataSources -}}
 apiVersion: v1
 kind: Secret
 metadata: 
@@ -20,31 +21,24 @@ stringData:
     apiVersion: 1
     
     datasources:
-{{- if $promEnabled -}}
-{{- $promEnv := (set (set (deepCopy .) "Values" .Values.prometheus) "Chart" (dict "Name" "prometheus")) -}}
-{{- $promServerName := (include "prometheus.server.fullname" $promEnv) -}}
-{{- $promServerUrl := printf "http://%s.%s.svc.cluster.local:%.0f" $promServerName .Release.Namespace .Values.prometheus.server.service.servicePort }}
+{{- if $promEnabled }}
       - name: Prometheus
         type: prometheus
-        url: {{ $promServerUrl }}
+        url: {{ tpl $ds.prometheus.urlTemplate . }}
         isDefault: true
         editable: true
         access: proxy
 {{- end -}}
-{{- if $tsEnabled -}}
-{{- $isDefault := not $promEnabled -}}
-{{- $tsEnv := (set (set (deepCopy .) "Values" (index .Values "timescaledb-single")) "Chart" (dict "Name" "timescaledb")) -}}
-{{- $tsHost := printf "%s.%s.svc.cluster.local" (include "clusterName" $tsEnv ) .Release.Namespace }}
+{{ if $tsEnabled -}}
+{{- $isDefault := not $promEnabled }}
       - name: TimescaleDB
-        url: {{ $tsHost }}
+        url: {{ tpl $ds.timescaledb.urlTemplate . }}
         type: postgres
         isDefault: {{ $isDefault }}
         access: proxy
-        user: postgres
+        user: {{ $ds.timescaledb.user }}
         database: postgres
         editable: true
-        secureJsonData:
-          password: {{ index .Values "timescaledb-single" "credentials" "postgres" }}
         jsonData:
           sslmode: require
           postgresVersion: 1000

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,6 +6,8 @@
 timescaledb-single:
   # disable the chart if an existing TimescaleDB instance is used
   enabled: true
+  image:
+    tag: pg12-ts1.7
   # create only a ClusterIP service
   loadBalancer: 
     enabled: false
@@ -33,10 +35,10 @@ timescale-prometheus:
     #  secretTemplate: "already-existing-secret"
     # to change the secret name by setting either a template or a string
     
-    # db host by default configured to "{{ .Release.Name }}.default.svc.cluster.local"
+    # db host by default configured to "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     # use:
     # host:
-    #  nameTemplate: "{{ .Release.Name }}.default.svc.cluster.local"
+    #  nameTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     # to change host name by setting either a template or a string
   
   # configuration options for the service exposed by timescale-prometheus
@@ -84,6 +86,26 @@ grafana:
   sidecar:
     datasources:
       enabled: true
+      # Provision a prometheus data source
+      prometheus:
+        enabled: true
+        # By default url of data source is set to prometheus instance 
+        # deployed with this chart
+        urlTemplate: "http://{{ .Release.Name}}-prometheus-server.{{ .Release.Namespace }}.svc.cluster.local"
+      # Provision a TimescaleDB data source
+      timescaledb:
+        enabled: true
+        # Run a Job that updates the search path so that grafana
+        # can autocomplete the metric name tables (which are stored in 
+        # the 'prom' schema)
+        alterSearchPath: true
+        user: postgres
+        # By default the url/host is set to the db instance deployed
+        # with this chart
+        urlTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+        # The secret containing the password for the user used 
+        # to connect to the database.
+        passwordSecretTemplate: "{{ .Release.Name }}-timescaledb-passwords"
     dashboards:
       enabled: true
       files:


### PR DESCRIPTION
In order for grafana to auto populate the metric table
names in their UI then the searchpath for the user
used to connect to the db must be updated to include
the prom and _prom_catalog schemas.

The grafana data-source configuration does not
allow the search path to be selected when
configuring or creating the data source.