### PR TITLE
Modify provisioned data-sources values to support external deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ The chart defines the following parameters in the `values.yaml` file:
 | `prometheus.pushgateway.enabled`                    | If true will create the Prometheus Push Gateway        | `false`    |
 | `prometheus.server.configMapOverrideName`           | The name of the ConfigMap that provides the Prometheus config. Resolves to `{{ .Release.Name }}-{{ .Values.prometheus.server.configMapOverrideName }}` | `prometheus-config` |
 | `grafana.enabled`                                   | If false, Grafana will not be created                 | `true`      |
-| `grafana.sidecar.datasources.enabled`               | If false, Prometheus and TimescaleDB will not be provisioned as datasources | `true` |
+| `grafana.sidecar.datasources.enabled`               | If false, no data sources will be provisioned | `true` |
+| `grafana.sidecar.datasources.prometheus.enabled` | If false, a Prometheus data source will not be provisioned | `true` |
+| `grafana.sidecar.datasources.prometheus.urlTemplate` | Template that will be parsed to the url of the Prometheus API. Defaults to Prometheus deployed with this chart  | `http://{{ .Release.Name }}-prometheus-service.{{ .Release.Namespace }}.svc.cluster.local` |
+| `grafana.sidecar.datasources.timescaledb.enabled` | If false a TimescaleDB data source will not be provisioned | `true` |
+| `grafana.sidecar.datasources.timescaledb.user` | User to connect to TimescaleDB | `postgres`
+| `grafana.sidecar.datasources.timescaledb.urlTemplate` | Template that will be parsed to the host of TimescaleDB, defaults to DB deployed with this chart | `{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local` |
 | `grafana.sidecar.dashboards.enabled`                | If false, no dashboards will be provisioned by default | `true`     |
 | `grafana.sidecar.dashboards.files`                  | Files with dashboard definitions (in JSON) to be provisioned | `['dashboards/k8s.json']` |
 
@@ -126,6 +131,19 @@ kubectl port-forward svc/<release_name>-grafana 8080:80
 And then navigate to http://localhost:8080.
 
 For all the properties that can be configured and more details on how to set up the Grafana deployment see the [Helm hub entry][grafana-helm-hub]
+
+### Provisioned Data Sources 
+
+The data sources for Prometheus and TimescaleDB are provisioned by default. But the TimescaleDB data source is
+set up without the password. Upon connecting to Grafana, you will need to set the password for the selected user.
+
+You can get the password from the TimescaleDB secret already created with 
+```
+kubectl get secret --namespace <namespace> <release_name>-timescaledb-passwords -o jsonpath="{.data.postgres}" | base64 --decode
+```
+
+Remember to substitute the name of the secret (`<release_name-timescaledb-passwords`) and the name of the user (`.data.postgres`)
+if you are not using the defaults.
 
 ## Contributing
 

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -188,6 +188,9 @@ For more information on running Prometheus, visit: https://prometheus.io/
 
    {{ template "grafana.fullname" $grafanaEnv }}.{{ template "grafana.namespace" $grafanaEnv }}.svc.cluster.local
 
+{{ if .Values.grafana.sidecar.datasources.timescaledb.enabled -}}
+3. The provisioned TimescaleDB data source requires that you set the connection password before using it!
+{{- end -}}
 {{- if not .Values.grafana.persistence.enabled }}
 
 #################################################################################

--- a/chart/templates/secret-grafana-datasources.yaml
+++ b/chart/templates/secret-grafana-datasources.yaml
@@ -1,9 +1,10 @@
-{{- $promEnabled := .Values.prometheus.server.enabled -}}
-{{- $tsEnabled := index .Values "timescaledb-single" "enabled" -}}
-{{- $anyDataSources := or $tsEnabled $promEnabled -}}
-{{ if $anyDataSources -}}
 {{ if .Values.grafana.enabled -}}
-{{ if .Values.grafana.sidecar.datasources.enabled }}
+{{- $ds := .Values.grafana.sidecar.datasources -}}
+{{ if $ds.enabled }}
+{{- $tsEnabled := $ds.timescaledb.enabled -}}
+{{- $promEnabled := $ds.prometheus.enabled -}}
+{{- $anyDataSources := and $tsEnabled $promEnabled -}}
+{{ if $anyDataSources -}}
 apiVersion: v1
 kind: Secret
 metadata: 
@@ -20,31 +21,24 @@ stringData:
     apiVersion: 1
     
     datasources:
-{{- if $promEnabled -}}
-{{- $promEnv := (set (set (deepCopy .) "Values" .Values.prometheus) "Chart" (dict "Name" "prometheus")) -}}
-{{- $promServerName := (include "prometheus.server.fullname" $promEnv) -}}
-{{- $promServerUrl := printf "http://%s.%s.svc.cluster.local:%.0f" $promServerName .Release.Namespace .Values.prometheus.server.service.servicePort }}
+{{- if $promEnabled }}
       - name: Prometheus
         type: prometheus
-        url: {{ $promServerUrl }}
+        url: {{ tpl $ds.prometheus.urlTemplate . }}
         isDefault: true
         editable: true
         access: proxy
 {{- end -}}
-{{- if $tsEnabled -}}
-{{- $isDefault := not $promEnabled -}}
-{{- $tsEnv := (set (set (deepCopy .) "Values" (index .Values "timescaledb-single")) "Chart" (dict "Name" "timescaledb")) -}}
-{{- $tsHost := printf "%s.%s.svc.cluster.local" (include "clusterName" $tsEnv ) .Release.Namespace }}
+{{ if $tsEnabled -}}
+{{- $isDefault := not $promEnabled }}
       - name: TimescaleDB
-        url: {{ $tsHost }}
+        url: {{ tpl $ds.timescaledb.urlTemplate . }}
         type: postgres
         isDefault: {{ $isDefault }}
         access: proxy
-        user: postgres
+        user: {{ $ds.timescaledb.user }}
         database: postgres
         editable: true
-        secureJsonData:
-          password: {{ index .Values "timescaledb-single" "credentials" "postgres" }}
         jsonData:
           sslmode: require
           postgresVersion: 1000

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -33,10 +33,10 @@ timescale-prometheus:
     #  secretTemplate: "already-existing-secret"
     # to change the secret name by setting either a template or a string
     
-    # db host by default configured to "{{ .Release.Name }}.default.svc.cluster.local"
+    # db host by default configured to "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     # use:
     # host:
-    #  nameTemplate: "{{ .Release.Name }}.default.svc.cluster.local"
+    #  nameTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     # to change host name by setting either a template or a string
   
   # configuration options for the service exposed by timescale-prometheus
@@ -84,6 +84,19 @@ grafana:
   sidecar:
     datasources:
       enabled: true
+      # Provision a prometheus data source
+      prometheus:
+        enabled: true
+        # By default url of data source is set to prometheus instance 
+        # deployed with this chart
+        urlTemplate: "http://{{ .Release.Name}}-prometheus-server.{{ .Release.Namespace }}.svc.cluster.local"
+      # Provision a TimescaleDB data source
+      timescaledb:
+        enabled: true
+        user: postgres
+        # By default the url/host is set to the db instance deployed
+        # with this chart
+        urlTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     dashboards:
       enabled: true
       files:


### PR DESCRIPTION
Previous configuration of provisioned data-sources would only work
for the case where prometheus and timescaledb were deployed within
the same release with this chart. This way they chart can support
grafana creating provisioned data sources for a timescaledb or
prometheus instance deployed or managed separately.