### PR TITLE
Use the alpha.2 image for the connector and update docs

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for the Timescale Observability Suite
 
 type: application
 
-version: 0.1.0-alpha.1
-appVersion: 0.1.0-alpha.1
+version: 0.1.0-alpha.2
+appVersion: 0.1.0-alpha.2
 
 dependencies:
   - name: timescaledb-single
@@ -14,7 +14,7 @@ dependencies:
     repository: https://charts.timescale.com
   - name: timescale-prometheus
     condition: timescale-prometheus.enabled
-    version: 0.1.0-alpha.1
+    version: 0.1.0-alpha.2
     repository: https://charts.timescale.com
   - name: prometheus
     condition: prometheus.enabled

--- a/chart/templates/secret-grafana-datasources.yaml
+++ b/chart/templates/secret-grafana-datasources.yaml
@@ -39,6 +39,8 @@ stringData:
         user: {{ $ds.timescaledb.user }}
         database: postgres
         editable: true
+        secureJsonData:
+          password: {{ index .Values "timescaledb-single" "credentials" $ds.timescaledb.user }}
         jsonData:
           sslmode: require
           postgresVersion: 1000

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -6,20 +6,24 @@
 timescaledb-single:
   # disable the chart if an existing TimescaleDB instance is used
   enabled: true
+  image:
+    tag: pg12-ts1.7
   # create only a ClusterIP service
   loadBalancer: 
     enabled: false
   # number or TimescaleDB pods to spawn (default is 3, 1 for no HA)
   replicaCount: 1
-
-
+  
 # Values for configuring the deployment of the Timescale Prometheus Connector
 # The charts README is at:
 #   https://github.com/timescale/timescale-prometheus/tree/master/helm-chart
 timescale-prometheus:
   enabled: true
+  image: timescale/timescale-prometheus:0.1.0-alpha.2
   # connection options
   connection:
+    # the db name in which the metrics will be stored
+    dbName: postgres
     # user to connect to TimescaleDB with
     # user: postgres
     # The secret containing the password for the user used 
@@ -38,7 +42,7 @@ timescale-prometheus:
     # host:
     #  nameTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
     # to change host name by setting either a template or a string
-  
+
   # configuration options for the service exposed by timescale-prometheus
   service:
     # we disable the load balancer by default, only a ClusterIP service


### PR DESCRIPTION
The README is updated to show the new config
options and restructured for readability. The new
image for the Timescale-Prometheus connector is used
along with TimescaleDB 1.7 on PG12.