### PR TITLE
 port-forwarding to the prometheus service

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -84,7 +84,7 @@ Get the Prometheus server URL by running these commands in the same shell:
   echo http://$SERVICE_IP:{{ .Values.prometheus.server.service.servicePort }}
 {{- else if contains "ClusterIP"  .Values.prometheus.server.service.type }}
   export SERVICE_NAME=$(kubectl get services --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus.name" $promEnv }},component={{ .Values.prometheus.server.name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl --namespace {{ .Release.Namespace }} port-forward service/$POD_NAME 9090:{{ .Values.prometheus.server.service.servicePort }} 
+  kubectl --namespace {{ .Release.Namespace }} port-forward service/$SERVICE_NAME 9090:{{ .Values.prometheus.server.service.servicePort }} 
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Updates notes to connect prometheus service port instead of pod port if the service type is ClusterIP
